### PR TITLE
Encrypt hex literals when needed

### DIFF
--- a/src/PdfSharp/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharp/Pdf.Internal/PdfEncoders.cs
@@ -398,6 +398,7 @@ namespace PdfSharp.Pdf.Internal
                 }
                 else
                 {
+                    securityHandler?.EncryptBytes(bytes);
                     pdf.Append('<');
                     for (int idx = 0; idx < count; idx++)
                         pdf.AppendFormat("{0:X2}", bytes[idx]);


### PR DESCRIPTION
Base PR: https://github.com/empira/PDFsharp/pull/162

We use your .NET Standard conversion from Nuget, but ran into this issue. Would be nice if you could update it with this fix, not sure if base project is still begin worked on.